### PR TITLE
Don't raise an exception when a subproperty is blank

### DIFF
--- a/Solution/Thought.vCards.UnitTests/vCardStandardReaderTests.cs
+++ b/Solution/Thought.vCards.UnitTests/vCardStandardReaderTests.cs
@@ -629,5 +629,20 @@ namespace Tests
 
         #endregion
 
+        #region [ ReadProperty_Blank_Subproperty ]
+
+        [Test]
+        public void ReadProperty_Blank_Subproperty()
+        {
+            vCardStandardReader reader =
+                new vCardStandardReader();
+
+            Assert.DoesNotThrow(
+                () => { reader.ReadProperty("NAME;:VALUE"); },
+                "Exception was thrown.");
+        }
+
+        #endregion
+
     }
 }

--- a/Solution/Thought.vCards/WarningMessages.Designer.cs
+++ b/Solution/Thought.vCards/WarningMessages.Designer.cs
@@ -86,5 +86,14 @@ namespace Thought.vCards {
                 return ResourceManager.GetString("EmptyName", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line {0}: The subproperty is empty..
+        /// </summary>
+        internal static string EmptySubProperty {
+            get {
+                return ResourceManager.GetString("EmptySubProperty", resourceCulture);
+            }
+        }
     }
 }

--- a/Solution/Thought.vCards/WarningMessages.resx
+++ b/Solution/Thought.vCards/WarningMessages.resx
@@ -126,4 +126,7 @@
   <data name="EmptyName" xml:space="preserve">
     <value>Line {0}: The name section of the property is empty.</value>
   </data>
+  <data name="EmptySubProperty" xml:space="preserve">
+    <value>Line {0}: The subproperty is empty.</value>
+  </data>
 </root>

--- a/Solution/Thought.vCards/vCardStandardReader.cs
+++ b/Solution/Thought.vCards/vCardStandardReader.cs
@@ -2074,8 +2074,18 @@ namespace Thought.vCards
                         // was present.  The subproperty consists of
                         // a name only.
 
-                        property.Subproperties.Add(
-                            nameParts[index].Trim());
+                        string name = nameParts[index].Trim();
+
+                        if (string.IsNullOrEmpty(name))
+                        {
+                            Warnings.Add(Thought.vCards.WarningMessages.EmptySubProperty);
+                        }
+                        else
+                        {
+                            property.Subproperties.Add(
+                                name);
+                        }
+
                     }
                     else
                     {


### PR DESCRIPTION
I have a vCard (from my phone) that has a property like:
<code>TEL;:0123 - 456 7890</code>
This raised an ArgumentIsNull exception. I think it should have parsed as if the property had been:
<code>TEL:0123 - 456 7890</code>
